### PR TITLE
feat: betonquest integration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -80,6 +80,7 @@ dependencies {
     compileOnly(libs.towny)
     compileOnly(libs.betonquest) {
         exclude("com.comphenix.packetwrapper", "PacketWrapper")
+        exclude("de.themoep", "minedown-adventure")
     }
     compileOnly(files("libs/AlathraPorts-1.0.1.jar"))
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,6 +40,7 @@ repositories {
     maven("https://repo.glaremasters.me/repository/towny/") { // Towny
         content { includeGroup("com.palmergames.bukkit.towny") }
     }
+    maven("https://nexus.betonquest.org/repository/betonquest/") // BetonQuest
 }
 
 dependencies {
@@ -77,6 +78,9 @@ dependencies {
         exclude("me.clip.placeholderapi.libs", "kyori")
     }
     compileOnly(libs.towny)
+    compileOnly(libs.betonquest) {
+        exclude("com.comphenix.packetwrapper", "PacketWrapper")
+    }
     compileOnly(files("libs/AlathraPorts-1.0.1.jar"))
 
     // Testing - Core
@@ -188,14 +192,14 @@ bukkit { // Options: https://github.com/Minecrell/plugin-yml#bukkit
     prefix = project.name
     version = "${project.version}"
     description = "${project.description}"
-    authors = listOf("darksaid98", "ShermansWorld", "rooooose-b")
+    authors = listOf("rooooose-b", "darksaid98", "ShermansWorld")
     contributors = listOf()
     apiVersion = "1.21"
     foliaSupported = true // Mark plugin as supporting Folia
 
     // Misc properties
     load = net.minecrell.pluginyml.bukkit.BukkitPluginDescription.PluginLoadOrder.POSTWORLD // STARTUP or POSTWORLD
-    depend = listOf("Towny")
+    depend = listOf("Towny", "BetonQuest")
     softDepend = listOf("PacketEvents", "Vault", "PlaceholderAPI")
     loadBefore = listOf()
     provides = listOf()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ threadutil-bukkit = "io.github.milkdrinkers:threadutil-bukkit:1.0.0"
 commandapi-shade = { module = "dev.jorel:commandapi-bukkit-shade", version.ref = "commandapi" }
 commandapi-annotations = { module = "dev.jorel:commandapi-annotations", version.ref = "commandapi" }
 triumph-gui = "dev.triumphteam:triumph-gui:3.1.11"
+betonquest = "org.betonquest:betonquest:2.2.1"
 
 # Plugin dependencies
 citizens = "net.citizensnpcs:citizens-main:2.0.38-SNAPSHOT"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,7 @@ threadutil-bukkit = "io.github.milkdrinkers:threadutil-bukkit:1.0.0"
 commandapi-shade = { module = "dev.jorel:commandapi-bukkit-shade", version.ref = "commandapi" }
 commandapi-annotations = { module = "dev.jorel:commandapi-annotations", version.ref = "commandapi" }
 triumph-gui = "dev.triumphteam:triumph-gui:3.1.11"
-betonquest = "org.betonquest:betonquest:2.2.1"
+betonquest = "org.betonquest:betonquest:3.0.0-SNAPSHOT"
 
 # Plugin dependencies
 citizens = "net.citizensnpcs:citizens-main:2.0.38-SNAPSHOT"

--- a/src/main/java/io/github/milkdrinkers/stewards/Stewards.java
+++ b/src/main/java/io/github/milkdrinkers/stewards/Stewards.java
@@ -5,6 +5,7 @@ import io.github.milkdrinkers.stewards.command.CommandHandler;
 import io.github.milkdrinkers.stewards.config.ConfigHandler;
 import io.github.milkdrinkers.stewards.hook.HookManager;
 import io.github.milkdrinkers.stewards.listener.ListenerHandler;
+import io.github.milkdrinkers.stewards.quest.BetonQuestHandler;
 import io.github.milkdrinkers.stewards.steward.StewardLookup;
 import io.github.milkdrinkers.stewards.steward.StewardTypeHandler;
 import io.github.milkdrinkers.stewards.threadutil.SchedulerHandler;
@@ -39,6 +40,8 @@ public class Stewards extends JavaPlugin {
     private StewardTypeHandler stewardTypeHandler;
     private StewardLookup stewardLookup;
 
+    private BetonQuestHandler betonQuestHandler;
+
     // Handlers list (defines order of load/enable/disable)
     private List<? extends Reloadable> handlers;
 
@@ -65,6 +68,7 @@ public class Stewards extends JavaPlugin {
         listenerHandler = new ListenerHandler(this);
         updateHandler = new UpdateHandler(this);
         schedulerHandler = new SchedulerHandler();
+        betonQuestHandler = new BetonQuestHandler();
 
         handlers = List.of(
             configHandler,
@@ -75,7 +79,8 @@ public class Stewards extends JavaPlugin {
             commandHandler,
             listenerHandler,
             updateHandler,
-            schedulerHandler
+            schedulerHandler,
+            betonQuestHandler
         );
 
         for (Reloadable handler : handlers)

--- a/src/main/java/io/github/milkdrinkers/stewards/command/StewardsCommand.java
+++ b/src/main/java/io/github/milkdrinkers/stewards/command/StewardsCommand.java
@@ -1,6 +1,7 @@
 package io.github.milkdrinkers.stewards.command;
 
 import dev.jorel.commandapi.CommandAPICommand;
+import dev.jorel.commandapi.arguments.PlayerArgument;
 import dev.jorel.commandapi.executors.CommandArguments;
 import io.github.milkdrinkers.settlers.api.settler.SettlerBuilder;
 import io.github.milkdrinkers.settlers.api.settler.Townfolk;
@@ -11,16 +12,21 @@ import io.github.milkdrinkers.stewards.steward.StewardLookup;
 import io.github.milkdrinkers.stewards.trait.ArchitectTrait;
 import io.github.milkdrinkers.stewards.trait.StewardTrait;
 import io.github.milkdrinkers.stewards.utility.Appearance;
+import io.github.milkdrinkers.stewards.utility.Cfg;
+import io.github.milkdrinkers.stewards.utility.Logger;
 import net.citizensnpcs.trait.HologramTrait;
 import net.citizensnpcs.trait.LookClose;
+import org.bukkit.Location;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+
+import java.time.Instant;
 
 /**
  * Class containing the code for the example command.
  */
 class StewardsCommand {
-    private static final String BASE_PERM = "example.command";
+    private static final String BASE_PERM = "stewards.command";
 
     /**
      * Instantiates and registers a new command.
@@ -28,22 +34,39 @@ class StewardsCommand {
     protected StewardsCommand() {
         new CommandAPICommand("stewards")
             .withSubcommands(
-                new TranslationCommand().command()
+                new TranslationCommand().command(),
+                new CommandAPICommand("getarchitect")
+                    .withArguments(new PlayerArgument("player"))
+                    .withPermission(BASE_PERM + ".getarchitect")
+                    .executes(this::executorSpawn)
             )
-            .executes(this::executorSpawn)
             .register();
     }
 
     private void executorSpawn(CommandSender sender, CommandArguments args) {
+        Player player = (Player) args.get("player");
+
+        if (player == null) {
+            Logger.get().error("Player argument is null.");
+            return;
+        }
+
+        if (!Cfg.get().getStringList("architect.allowed-worlds").contains(player.getWorld().getName())) {
+            Logger.get().error("Player is not in an allowed world.");
+            return;
+        }
+
         try {
             boolean female = Math.random() > 0.5;
             String name = Appearance.getMaleName();
             if (female)
                 name = Appearance.getFemaleName();
 
+            Location spawnLocation = player.getLocation().add(1, 0, 0);
+
             Townfolk settler = new SettlerBuilder()
                 .setName(name)
-                .setLocation(((Player) sender).getLocation())
+                .setLocation(spawnLocation)
                 .createTownfolk();
 
             Steward steward = Steward.builder()
@@ -60,12 +83,14 @@ class StewardsCommand {
             stewardTrait.setFemale(female);
             stewardTrait.setLevel(1);
 
-            steward.getSettler().getNpc().getOrAddTrait(ArchitectTrait.class);
+            ArchitectTrait architectTrait = steward.getSettler().getNpc().getOrAddTrait(ArchitectTrait.class);
+            architectTrait.setCreateTime(Instant.now());
+            architectTrait.setSpawningPlayer(player.getUniqueId());
 
             HologramTrait hologramTrait = steward.getSettler().getNpc().getOrAddTrait(HologramTrait.class);
             hologramTrait.addLine("&7[&6" + steward.getStewardType().getName() + "&7]");
 
-            steward.getSettler().getNpc().getOrAddTrait(LookClose.class);
+            steward.getSettler().getNpc().getOrAddTrait(LookClose.class).setRange(16);
 
             if (female) {
                 Appearance.applyFemaleStewardSkin(steward);
@@ -76,6 +101,8 @@ class StewardsCommand {
             StewardLookup.get().registerSteward(steward);
 
             settler.spawn();
+
+            steward.startFollowing(player);
         } catch (InvalidStewardException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/io/github/milkdrinkers/stewards/conversation/SpawnArchitectConversation.java
+++ b/src/main/java/io/github/milkdrinkers/stewards/conversation/SpawnArchitectConversation.java
@@ -28,6 +28,10 @@ public class SpawnArchitectConversation {
     private static Player player;
     private static Location spawnLocation;
 
+    @Deprecated
+    /**
+     * @deprecated Deprecated in favor of conditions registered in {@link io.github.milkdrinkers.stewards.quest.BetonQuestHandler}
+     */
     public static Prompt getSpawnArchitectPrompt(Player player, Location spawnLocation) {
         SpawnArchitectConversation.player = player;
         SpawnArchitectConversation.spawnLocation = spawnLocation;

--- a/src/main/java/io/github/milkdrinkers/stewards/quest/BetonQuestHandler.java
+++ b/src/main/java/io/github/milkdrinkers/stewards/quest/BetonQuestHandler.java
@@ -2,6 +2,8 @@ package io.github.milkdrinkers.stewards.quest;
 
 import io.github.milkdrinkers.stewards.Reloadable;
 import io.github.milkdrinkers.stewards.Stewards;
+import io.github.milkdrinkers.stewards.quest.condition.CanAffordArchitectConditionFactory;
+import io.github.milkdrinkers.stewards.quest.condition.HasArchitectConditionFactory;
 import io.github.milkdrinkers.stewards.quest.condition.HasTownConditionFactory;
 import org.betonquest.betonquest.BetonQuest;
 import org.betonquest.betonquest.api.logger.BetonQuestLoggerFactory;
@@ -18,7 +20,9 @@ public class BetonQuestHandler implements Reloadable {
         final BetonQuestLoggerFactory loggerFactory = BetonQuest.getInstance().getLoggerFactory();
         final PrimaryServerThreadData data = new PrimaryServerThreadData(plugin.getServer(), plugin.getServer().getScheduler(), plugin);
 
-        BetonQuest.getInstance().getQuestRegistries().getConditionTypes().register("stewardhastown", new HasTownConditionFactory(loggerFactory, data));
+        BetonQuest.getInstance().getQuestRegistries().getConditionTypes().register("stewardshastown", new HasTownConditionFactory(loggerFactory, data));
+        BetonQuest.getInstance().getQuestRegistries().getConditionTypes().register("stewardshasarchitect", new HasArchitectConditionFactory(loggerFactory, data));
+        BetonQuest.getInstance().getQuestRegistries().getConditionTypes().register("stewardscanaffordarchitect", new CanAffordArchitectConditionFactory(loggerFactory, data));
     }
 
     @Override

--- a/src/main/java/io/github/milkdrinkers/stewards/quest/BetonQuestHandler.java
+++ b/src/main/java/io/github/milkdrinkers/stewards/quest/BetonQuestHandler.java
@@ -1,0 +1,28 @@
+package io.github.milkdrinkers.stewards.quest;
+
+import io.github.milkdrinkers.stewards.Reloadable;
+import io.github.milkdrinkers.stewards.Stewards;
+import io.github.milkdrinkers.stewards.quest.condition.HasTownConditionFactory;
+import org.betonquest.betonquest.BetonQuest;
+import org.betonquest.betonquest.api.logger.BetonQuestLoggerFactory;
+import org.betonquest.betonquest.quest.PrimaryServerThreadData;
+
+public class BetonQuestHandler implements Reloadable {
+    @Override
+    public void onLoad(Stewards plugin) {
+
+    }
+
+    @Override
+    public void onEnable(Stewards plugin) {
+        final BetonQuestLoggerFactory loggerFactory = BetonQuest.getInstance().getLoggerFactory();
+        final PrimaryServerThreadData data = new PrimaryServerThreadData(plugin.getServer(), plugin.getServer().getScheduler(), plugin);
+
+        BetonQuest.getInstance().getQuestRegistries().getConditionTypes().register("stewardhastown", new HasTownConditionFactory(loggerFactory, data));
+    }
+
+    @Override
+    public void onDisable(Stewards plugin) {
+
+    }
+}

--- a/src/main/java/io/github/milkdrinkers/stewards/quest/BetonQuestHandler.java
+++ b/src/main/java/io/github/milkdrinkers/stewards/quest/BetonQuestHandler.java
@@ -20,9 +20,9 @@ public class BetonQuestHandler implements Reloadable {
         final BetonQuestLoggerFactory loggerFactory = BetonQuest.getInstance().getLoggerFactory();
         final PrimaryServerThreadData data = new PrimaryServerThreadData(plugin.getServer(), plugin.getServer().getScheduler(), plugin);
 
-        BetonQuest.getInstance().getQuestRegistries().getConditionTypes().register("stewardshastown", new HasTownConditionFactory(loggerFactory, data));
-        BetonQuest.getInstance().getQuestRegistries().getConditionTypes().register("stewardshasarchitect", new HasArchitectConditionFactory(loggerFactory, data));
-        BetonQuest.getInstance().getQuestRegistries().getConditionTypes().register("stewardscanaffordarchitect", new CanAffordArchitectConditionFactory(loggerFactory, data));
+        BetonQuest.getInstance().getQuestRegistries().condition().register("stewardshastown", new HasTownConditionFactory(loggerFactory, data));
+        BetonQuest.getInstance().getQuestRegistries().condition().register("stewardshasarchitect", new HasArchitectConditionFactory(loggerFactory, data));
+        BetonQuest.getInstance().getQuestRegistries().condition().register("stewardscanaffordarchitect", new CanAffordArchitectConditionFactory(loggerFactory, data));
     }
 
     @Override

--- a/src/main/java/io/github/milkdrinkers/stewards/quest/condition/CanAffordArchitectCondition.java
+++ b/src/main/java/io/github/milkdrinkers/stewards/quest/condition/CanAffordArchitectCondition.java
@@ -1,0 +1,20 @@
+package io.github.milkdrinkers.stewards.quest.condition;
+
+import com.palmergames.bukkit.towny.TownySettings;
+import io.github.milkdrinkers.stewards.hook.Hook;
+import org.betonquest.betonquest.api.profiles.OnlineProfile;
+import org.betonquest.betonquest.api.quest.condition.online.OnlineCondition;
+import org.betonquest.betonquest.exceptions.QuestRuntimeException;
+import org.bukkit.entity.Player;
+
+public class CanAffordArchitectCondition implements OnlineCondition {
+    @Override
+    public boolean check(OnlineProfile profile) throws QuestRuntimeException {
+        Player player = profile.getPlayer().getPlayer();
+
+        if (player == null)
+            throw new QuestRuntimeException("Player is null.");
+
+        return Hook.getVaultHook().getEconomy().getBalance(player) > TownySettings.getNewTownPrice();
+    }
+}

--- a/src/main/java/io/github/milkdrinkers/stewards/quest/condition/CanAffordArchitectCondition.java
+++ b/src/main/java/io/github/milkdrinkers/stewards/quest/condition/CanAffordArchitectCondition.java
@@ -2,18 +2,18 @@ package io.github.milkdrinkers.stewards.quest.condition;
 
 import com.palmergames.bukkit.towny.TownySettings;
 import io.github.milkdrinkers.stewards.hook.Hook;
-import org.betonquest.betonquest.api.profiles.OnlineProfile;
+import org.betonquest.betonquest.api.profile.OnlineProfile;
+import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.api.quest.condition.online.OnlineCondition;
-import org.betonquest.betonquest.exceptions.QuestRuntimeException;
 import org.bukkit.entity.Player;
 
 public class CanAffordArchitectCondition implements OnlineCondition {
     @Override
-    public boolean check(OnlineProfile profile) throws QuestRuntimeException {
+    public boolean check(OnlineProfile profile) throws QuestException {
         Player player = profile.getPlayer().getPlayer();
 
         if (player == null)
-            throw new QuestRuntimeException("Player is null.");
+            throw new QuestException("Player is null.");
 
         return Hook.getVaultHook().getEconomy().getBalance(player) > TownySettings.getNewTownPrice();
     }

--- a/src/main/java/io/github/milkdrinkers/stewards/quest/condition/CanAffordArchitectConditionFactory.java
+++ b/src/main/java/io/github/milkdrinkers/stewards/quest/condition/CanAffordArchitectConditionFactory.java
@@ -1,12 +1,12 @@
 package io.github.milkdrinkers.stewards.quest.condition;
 
-import org.betonquest.betonquest.Instruction;
+import org.betonquest.betonquest.instruction.Instruction;
 import org.betonquest.betonquest.api.logger.BetonQuestLogger;
 import org.betonquest.betonquest.api.logger.BetonQuestLoggerFactory;
+import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.api.quest.condition.PlayerCondition;
 import org.betonquest.betonquest.api.quest.condition.PlayerConditionFactory;
 import org.betonquest.betonquest.api.quest.condition.online.OnlineConditionAdapter;
-import org.betonquest.betonquest.exceptions.InstructionParseException;
 import org.betonquest.betonquest.quest.PrimaryServerThreadData;
 import org.betonquest.betonquest.quest.condition.PrimaryServerThreadPlayerCondition;
 
@@ -22,7 +22,7 @@ public class CanAffordArchitectConditionFactory implements PlayerConditionFactor
     }
 
     @Override
-    public PlayerCondition parsePlayer(Instruction instruction) throws InstructionParseException {
+    public PlayerCondition parsePlayer(Instruction instruction) throws QuestException {
         final BetonQuestLogger logger = loggerFactory.create(CanAffordArchitectCondition.class);
         return new PrimaryServerThreadPlayerCondition(new OnlineConditionAdapter(new CanAffordArchitectCondition(), logger, instruction.getPackage()), data);
     }

--- a/src/main/java/io/github/milkdrinkers/stewards/quest/condition/CanAffordArchitectConditionFactory.java
+++ b/src/main/java/io/github/milkdrinkers/stewards/quest/condition/CanAffordArchitectConditionFactory.java
@@ -1,0 +1,29 @@
+package io.github.milkdrinkers.stewards.quest.condition;
+
+import org.betonquest.betonquest.Instruction;
+import org.betonquest.betonquest.api.logger.BetonQuestLogger;
+import org.betonquest.betonquest.api.logger.BetonQuestLoggerFactory;
+import org.betonquest.betonquest.api.quest.condition.PlayerCondition;
+import org.betonquest.betonquest.api.quest.condition.PlayerConditionFactory;
+import org.betonquest.betonquest.api.quest.condition.online.OnlineConditionAdapter;
+import org.betonquest.betonquest.exceptions.InstructionParseException;
+import org.betonquest.betonquest.quest.PrimaryServerThreadData;
+import org.betonquest.betonquest.quest.condition.PrimaryServerThreadPlayerCondition;
+
+public class CanAffordArchitectConditionFactory implements PlayerConditionFactory {
+
+    private final BetonQuestLoggerFactory loggerFactory;
+
+    private final PrimaryServerThreadData data;
+
+    public CanAffordArchitectConditionFactory(BetonQuestLoggerFactory loggerFactory, PrimaryServerThreadData data) {
+        this.loggerFactory = loggerFactory;
+        this.data = data;
+    }
+
+    @Override
+    public PlayerCondition parsePlayer(Instruction instruction) throws InstructionParseException {
+        final BetonQuestLogger logger = loggerFactory.create(CanAffordArchitectCondition.class);
+        return new PrimaryServerThreadPlayerCondition(new OnlineConditionAdapter(new CanAffordArchitectCondition(), logger, instruction.getPackage()), data);
+    }
+}

--- a/src/main/java/io/github/milkdrinkers/stewards/quest/condition/HasArchitectCondition.java
+++ b/src/main/java/io/github/milkdrinkers/stewards/quest/condition/HasArchitectCondition.java
@@ -1,18 +1,18 @@
 package io.github.milkdrinkers.stewards.quest.condition;
 
 import io.github.milkdrinkers.stewards.steward.StewardLookup;
-import org.betonquest.betonquest.api.profiles.OnlineProfile;
+import org.betonquest.betonquest.api.profile.OnlineProfile;
+import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.api.quest.condition.online.OnlineCondition;
-import org.betonquest.betonquest.exceptions.QuestRuntimeException;
 import org.bukkit.entity.Player;
 
 public class HasArchitectCondition implements OnlineCondition {
     @Override
-    public boolean check(OnlineProfile profile) throws QuestRuntimeException {
+    public boolean check(OnlineProfile profile) throws QuestException {
         Player player = profile.getPlayer().getPlayer();
 
         if (player == null)
-            throw new QuestRuntimeException("Player is null.");
+            throw new QuestException("Player is null.");
 
         return StewardLookup.get().hasArchitect(player);
     }

--- a/src/main/java/io/github/milkdrinkers/stewards/quest/condition/HasArchitectCondition.java
+++ b/src/main/java/io/github/milkdrinkers/stewards/quest/condition/HasArchitectCondition.java
@@ -1,0 +1,19 @@
+package io.github.milkdrinkers.stewards.quest.condition;
+
+import io.github.milkdrinkers.stewards.steward.StewardLookup;
+import org.betonquest.betonquest.api.profiles.OnlineProfile;
+import org.betonquest.betonquest.api.quest.condition.online.OnlineCondition;
+import org.betonquest.betonquest.exceptions.QuestRuntimeException;
+import org.bukkit.entity.Player;
+
+public class HasArchitectCondition implements OnlineCondition {
+    @Override
+    public boolean check(OnlineProfile profile) throws QuestRuntimeException {
+        Player player = profile.getPlayer().getPlayer();
+
+        if (player == null)
+            throw new QuestRuntimeException("Player is null.");
+
+        return StewardLookup.get().hasArchitect(player);
+    }
+}

--- a/src/main/java/io/github/milkdrinkers/stewards/quest/condition/HasArchitectConditionFactory.java
+++ b/src/main/java/io/github/milkdrinkers/stewards/quest/condition/HasArchitectConditionFactory.java
@@ -1,0 +1,29 @@
+package io.github.milkdrinkers.stewards.quest.condition;
+
+import org.betonquest.betonquest.Instruction;
+import org.betonquest.betonquest.api.logger.BetonQuestLogger;
+import org.betonquest.betonquest.api.logger.BetonQuestLoggerFactory;
+import org.betonquest.betonquest.api.quest.condition.PlayerCondition;
+import org.betonquest.betonquest.api.quest.condition.PlayerConditionFactory;
+import org.betonquest.betonquest.api.quest.condition.online.OnlineConditionAdapter;
+import org.betonquest.betonquest.exceptions.InstructionParseException;
+import org.betonquest.betonquest.quest.PrimaryServerThreadData;
+import org.betonquest.betonquest.quest.condition.PrimaryServerThreadPlayerCondition;
+
+public class HasArchitectConditionFactory implements PlayerConditionFactory {
+
+    private final BetonQuestLoggerFactory loggerFactory;
+
+    private final PrimaryServerThreadData data;
+
+    public HasArchitectConditionFactory(BetonQuestLoggerFactory loggerFactory, PrimaryServerThreadData data) {
+        this.loggerFactory = loggerFactory;
+        this.data = data;
+    }
+
+    @Override
+    public PlayerCondition parsePlayer(Instruction instruction) throws InstructionParseException {
+        final BetonQuestLogger logger = loggerFactory.create(HasArchitectCondition.class);
+        return new PrimaryServerThreadPlayerCondition(new OnlineConditionAdapter(new HasArchitectCondition(), logger, instruction.getPackage()), data);
+    }
+}

--- a/src/main/java/io/github/milkdrinkers/stewards/quest/condition/HasArchitectConditionFactory.java
+++ b/src/main/java/io/github/milkdrinkers/stewards/quest/condition/HasArchitectConditionFactory.java
@@ -1,12 +1,12 @@
 package io.github.milkdrinkers.stewards.quest.condition;
 
-import org.betonquest.betonquest.Instruction;
+import org.betonquest.betonquest.instruction.Instruction;
 import org.betonquest.betonquest.api.logger.BetonQuestLogger;
 import org.betonquest.betonquest.api.logger.BetonQuestLoggerFactory;
+import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.api.quest.condition.PlayerCondition;
 import org.betonquest.betonquest.api.quest.condition.PlayerConditionFactory;
 import org.betonquest.betonquest.api.quest.condition.online.OnlineConditionAdapter;
-import org.betonquest.betonquest.exceptions.InstructionParseException;
 import org.betonquest.betonquest.quest.PrimaryServerThreadData;
 import org.betonquest.betonquest.quest.condition.PrimaryServerThreadPlayerCondition;
 
@@ -22,7 +22,7 @@ public class HasArchitectConditionFactory implements PlayerConditionFactory {
     }
 
     @Override
-    public PlayerCondition parsePlayer(Instruction instruction) throws InstructionParseException {
+    public PlayerCondition parsePlayer(Instruction instruction) throws QuestException {
         final BetonQuestLogger logger = loggerFactory.create(HasArchitectCondition.class);
         return new PrimaryServerThreadPlayerCondition(new OnlineConditionAdapter(new HasArchitectCondition(), logger, instruction.getPackage()), data);
     }

--- a/src/main/java/io/github/milkdrinkers/stewards/quest/condition/HasTownCondition.java
+++ b/src/main/java/io/github/milkdrinkers/stewards/quest/condition/HasTownCondition.java
@@ -2,23 +2,23 @@ package io.github.milkdrinkers.stewards.quest.condition;
 
 import com.palmergames.bukkit.towny.TownyAPI;
 import com.palmergames.bukkit.towny.object.Resident;
-import org.betonquest.betonquest.api.profiles.OnlineProfile;
+import org.betonquest.betonquest.api.profile.OnlineProfile;
+import org.betonquest.betonquest.api.quest.QuestException;
 import org.betonquest.betonquest.api.quest.condition.online.OnlineCondition;
-import org.betonquest.betonquest.exceptions.QuestRuntimeException;
 import org.bukkit.entity.Player;
 
 public class HasTownCondition implements OnlineCondition {
     @Override
-    public boolean check(OnlineProfile profile) throws QuestRuntimeException {
+    public boolean check(OnlineProfile profile) throws QuestException {
         Player player = profile.getPlayer().getPlayer();
 
         if (player == null)
-            throw new QuestRuntimeException("Player is null.");
+            throw new QuestException("Player is null.");
 
         Resident resident = TownyAPI.getInstance().getResident(player);
 
         if (resident == null)
-            throw new QuestRuntimeException("Player does not have a valid resident.");
+            throw new QuestException("Player does not have a valid resident.");
 
         return resident.hasTown();
     }

--- a/src/main/java/io/github/milkdrinkers/stewards/quest/condition/HasTownCondition.java
+++ b/src/main/java/io/github/milkdrinkers/stewards/quest/condition/HasTownCondition.java
@@ -1,0 +1,25 @@
+package io.github.milkdrinkers.stewards.quest.condition;
+
+import com.palmergames.bukkit.towny.TownyAPI;
+import com.palmergames.bukkit.towny.object.Resident;
+import org.betonquest.betonquest.api.profiles.OnlineProfile;
+import org.betonquest.betonquest.api.quest.condition.online.OnlineCondition;
+import org.betonquest.betonquest.exceptions.QuestRuntimeException;
+import org.bukkit.entity.Player;
+
+public class HasTownCondition implements OnlineCondition {
+    @Override
+    public boolean check(OnlineProfile profile) throws QuestRuntimeException {
+        Player player = profile.getPlayer().getPlayer();
+
+        if (player == null)
+            throw new QuestRuntimeException("Player is null.");
+
+        Resident resident = TownyAPI.getInstance().getResident(player);
+
+        if (resident == null)
+            throw new QuestRuntimeException("Player does not have a valid resident.");
+
+        return resident.hasTown();
+    }
+}

--- a/src/main/java/io/github/milkdrinkers/stewards/quest/condition/HasTownConditionFactory.java
+++ b/src/main/java/io/github/milkdrinkers/stewards/quest/condition/HasTownConditionFactory.java
@@ -1,0 +1,29 @@
+package io.github.milkdrinkers.stewards.quest.condition;
+
+import org.betonquest.betonquest.Instruction;
+import org.betonquest.betonquest.api.logger.BetonQuestLogger;
+import org.betonquest.betonquest.api.logger.BetonQuestLoggerFactory;
+import org.betonquest.betonquest.api.quest.condition.PlayerCondition;
+import org.betonquest.betonquest.api.quest.condition.PlayerConditionFactory;
+import org.betonquest.betonquest.api.quest.condition.online.OnlineConditionAdapter;
+import org.betonquest.betonquest.exceptions.InstructionParseException;
+import org.betonquest.betonquest.quest.PrimaryServerThreadData;
+import org.betonquest.betonquest.quest.condition.PrimaryServerThreadPlayerCondition;
+
+public class HasTownConditionFactory implements PlayerConditionFactory {
+
+    private final BetonQuestLoggerFactory loggerFactory;
+
+    private final PrimaryServerThreadData data;
+
+    public HasTownConditionFactory(BetonQuestLoggerFactory loggerFactory, PrimaryServerThreadData data) {
+        this.loggerFactory = loggerFactory;
+        this.data = data;
+    }
+
+    @Override
+    public PlayerCondition parsePlayer(Instruction instruction) throws InstructionParseException {
+        final BetonQuestLogger logger = loggerFactory.create(HasTownCondition.class);
+        return new PrimaryServerThreadPlayerCondition(new OnlineConditionAdapter(new HasTownCondition(), logger, instruction.getPackage()), data);
+    }
+}

--- a/src/main/java/io/github/milkdrinkers/stewards/quest/condition/HasTownConditionFactory.java
+++ b/src/main/java/io/github/milkdrinkers/stewards/quest/condition/HasTownConditionFactory.java
@@ -1,12 +1,12 @@
 package io.github.milkdrinkers.stewards.quest.condition;
 
-import org.betonquest.betonquest.Instruction;
+import org.betonquest.betonquest.api.quest.QuestException;
+import org.betonquest.betonquest.instruction.Instruction;
 import org.betonquest.betonquest.api.logger.BetonQuestLogger;
 import org.betonquest.betonquest.api.logger.BetonQuestLoggerFactory;
 import org.betonquest.betonquest.api.quest.condition.PlayerCondition;
 import org.betonquest.betonquest.api.quest.condition.PlayerConditionFactory;
 import org.betonquest.betonquest.api.quest.condition.online.OnlineConditionAdapter;
-import org.betonquest.betonquest.exceptions.InstructionParseException;
 import org.betonquest.betonquest.quest.PrimaryServerThreadData;
 import org.betonquest.betonquest.quest.condition.PrimaryServerThreadPlayerCondition;
 
@@ -22,7 +22,7 @@ public class HasTownConditionFactory implements PlayerConditionFactory {
     }
 
     @Override
-    public PlayerCondition parsePlayer(Instruction instruction) throws InstructionParseException {
+    public PlayerCondition parsePlayer(Instruction instruction) throws QuestException {
         final BetonQuestLogger logger = loggerFactory.create(HasTownCondition.class);
         return new PrimaryServerThreadPlayerCondition(new OnlineConditionAdapter(new HasTownCondition(), logger, instruction.getPackage()), data);
     }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -6,6 +6,9 @@ update-checker:
 
 # Language, specify the language file to use, for example `en_US` which will load `/lang/en_US.json`
 language: "en_US"
+architect:
+  allowed-worlds:
+    - "world"
 bailiff:
   claims:
     level-1: 20 # Additional claims added by the bailiff.


### PR DESCRIPTION
Adds `stewardshasarchitect`, `stewardshastown` and `stewardscanaffordarchitect` as `OnlineCondition` - note that we **do not want these to be** `PlayerCondition`, as we don't want the player to be offline when the architect is spawned. An `OnlineCondition` will return `false` if the player is offline.

Adds config option `architect.allowed-worlds`, which takes a list of strings.

Have not added config option `architect.cost`, as this is fetched from Towny API (**let me know if you want this to be added**)